### PR TITLE
Fix for unicode escape sequences in title

### DIFF
--- a/livestream_saver/download.py
+++ b/livestream_saver/download.py
@@ -486,7 +486,7 @@ We assume a failed download attempt. Last segment available was {seg}.")
             # FIXME this avoids writing this file more than once for now.
             # No further updates.
             return
-        with open(metadata_file, 'w') as fp:
+        with open(metadata_file, 'w', encoding='utf8') as fp:
             dump(obj=self.video_info, fp=fp, indent=4, ensure_ascii=False)
 
     @property


### PR DESCRIPTION
Should fix "UnicodeEncodeError: 'charmap' codec can't encode character" when dumping info to json
Test case:
[test.txt](https://github.com/glubsy/livestream_saver/files/6925377/test.txt)
