### PR TITLE
Fixed missing argument for args["ignore_quality_change"]

### DIFF
--- a/livestream_saver.py
+++ b/livestream_saver.py
@@ -889,7 +889,7 @@ def main():
         URL = args.get("URL", "")  # pass empty string for get_video_id()
         args["hooks"] = get_hooks_for_section(sub_cmd, config, "_command")
         args["cookie"] = config.get(sub_cmd, "cookie", vars=args, fallback=None)
-        args["ignore_quality_change"] = config.get(
+        args["ignore_quality_change"] = config.getboolean(
             sub_cmd, "ignore_quality_change", vars=args, fallback=False)
 
         NOTIFIER.webhooks = get_hooks_for_section(sub_cmd, config, "_webhook")

--- a/livestream_saver.py
+++ b/livestream_saver.py
@@ -890,7 +890,7 @@ def main():
         args["hooks"] = get_hooks_for_section(sub_cmd, config, "_command")
         args["cookie"] = config.get(sub_cmd, "cookie", vars=args, fallback=None)
         args["ignore_quality_change"] = config.get(
-            "ignore_quality_change", vars=args, fallback=False)
+            sub_cmd, "ignore_quality_change", vars=args, fallback=False)
 
         NOTIFIER.webhooks = get_hooks_for_section(sub_cmd, config, "_webhook")
         NOTIFIER.setup(config, args)


### PR DESCRIPTION
Very small bug fix for "TypeError: get() missing 1 required positional argument: 'option'" that occurred when running the application.