### PR TITLE
Fix warnings when number of video Ids differ from the previous state

### DIFF
--- a/livestream_saver/exceptions.py
+++ b/livestream_saver/exceptions.py
@@ -71,9 +71,3 @@ class ForbiddenSegmentException(Exception):
 
 class TabNotFound(Exception):
     pass
-
-class UnexpectedLength(Exception):
-    """
-    Happens when user gets logged out and less videos are returned for a given tab.
-    """
-    pass

--- a/livestream_saver/livestream_saver.py
+++ b/livestream_saver/livestream_saver.py
@@ -1046,8 +1046,8 @@ def main():
         print("Wrong sub-command. Exiting.")
         return
 
-    if "cookiefile" not in args["ytdlp_config"] and args.get("cookies") is not None:
-        args["ytdlp_config"]["cookiefile"] = args.get("cookies")
+    if "cookiefile" not in args["ytdlp_config"] and (cookies := args.get("cookies")):
+        args["ytdlp_config"]["cookiefile"] = cookies
 
     error = 0
     try:

--- a/ytdlp_config.json
+++ b/ytdlp_config.json
@@ -5,7 +5,8 @@
     // otherwise fallback to "best" according to yt-dlp's logic
     "format": "mp4+m4a/bestvideo+bestaudio",
     
-    // Path to your cookies (this is always updated from livestream_saver's --cookies argument)
+    // Path to your cookies (this value is replaced by the value 
+    // submitted via the --cookies parameter to livestream_saver)
     // "cookiefile": "",
     
     // Do not stop on download/postprocessing errors.


### PR DESCRIPTION
* Refactor checks done after fetching video Ids for each tab
* Reduce logged warnings due to a decrease in the number of video Ids returned for a tab/page: this is expected as we do not collect all video Ids available for a given tab (we only care about the the first page). This check is done to detect that we have been logged out, which usually results in much less video Ids returned for the "membership" and "community" tabs.
* Fix passing blank cookiee file path to yt-dlp which results in non-fatal error when yt-dlp tries to update cookies on disk (at the end of a stream download)
* Remove dead code that used to fetch the "upcoming" tab data. That tab does not seem to exist anymore.