### PR TITLE
Fix downloader: only use ytdlp for probing information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Configurable `use_ytdl` setting in the template configuration file to let users choose the downloader
 - Support for resuming muxed HLS downloads from existing segment output directories
 - Support for merging single-track muxed segment downloads without requiring an `aud/` directory
+- Dedicated Docker Compose service for the external bgutil POT provider
+- Podman-specific Compose override file using host networking
+- Optional dependency group / requirements file for POT-related yt-dlp integration
 
 ### Changed
 - BREAKING: Renamed `max_video_quality` to `max_video_width` in configuration handling
@@ -20,11 +23,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Reduced dependency on pytube metadata lookups in the yt-dlp/HLS download path
 - Improved merge logging for valid partial-duration recordings
 - Renamed extracted thumbnails to match the final output filename and correct image extension
+- Moved the bgutil POT provider out of the downloader container image and into a separate service
+- Moved POT-related Python package out of the default dependency set and into optional installation paths
+- Updated Docker and installation documentation to describe the external POT provider requirement
 
 ### Fixed
 - Fixed selection of the most appropriate muxed HLS format based on the configured maximum video width
 - Fixed incorrect fallback to old YouTube API metadata calls during yt-dlp-driven HLS downloads
 - Fixed noisy segment progress messages being written to download log files
+- Fixed cookie path handling when paths contain `~`, including `_updated.txt` cookie jar writes
+- Fixed Podman Compose progress display by disabling TTY in the Podman override
+- Fixed muxed HLS resume behavior when playlist media sequence has already advanced
 
 ## [v1.0.1] - 2026-06-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [v2.0.0] - 2026-06-15
+
+### Added
+- Support for using yt-dlp to discover livestream formats and download muxed HLS segment streams
+- Configurable `use_ytdl` setting in the template configuration file to let users choose the downloader
+- Support for resuming muxed HLS downloads from existing segment output directories
+- Support for merging single-track muxed segment downloads without requiring an `aud/` directory
+
+### Changed
+- BREAKING: Renamed `max_video_quality` to `max_video_width` in configuration handling
+- Renamed the preferred CLI flag to `--max-video-width` while keeping `--max-video-quality` as a compatibility alias
+- Updated yt-dlp probing so format filters such as `format` and `format_sort` are removed before stream discovery
+- Reduced dependency on pytube metadata lookups in the yt-dlp/HLS download path
+- Improved merge logging for valid partial-duration recordings
+- Renamed extracted thumbnails to match the final output filename and correct image extension
+
+### Fixed
+- Fixed selection of the most appropriate muxed HLS format based on the configured maximum video width
+- Fixed incorrect fallback to old YouTube API metadata calls during yt-dlp-driven HLS downloads
+- Fixed noisy segment progress messages being written to download log files
+
 ## [v1.0.1] - 2026-06-13
 
 - Fix video Ids being wrongly detected as newly added to the channel

--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ options:
                         Path to config file to use. (Default: ~/.config/livestream_saver/livestream_saver.cfg)
   --cookies COOKIES_PATH
                         Path to Netscape formatted cookies file.
-  -q MAX_VIDEO_QUALITY, --max-video-quality MAX_VIDEO_QUALITY
-                        Use best available video resolution up to this height in pixels. Example: "360" for maximum height 360p. Get the highest available resolution by
+  -q MAX_VIDEO_WIDTH, --max-video-width MAX_VIDEO_WIDTH
+                        Use best available video resolution up to this width in pixels. Example: "360" for maximum width of 360p. Get the highest available resolution by
                         default.
   -o OUTPUT_DIR, --output-dir OUTPUT_DIR
                         Output directory where to save channel data. (Default: CWD)
@@ -89,8 +89,8 @@ optional arguments:
   -c CONFIG_FILE, --config-file CONFIG_FILE
                         Path to config file to use. (Default: ~/.config/livestream_saver/livestream_saver.cfg)
   --cookies COOKIES_PATH  Path to Netscape formatted cookies file.
-  -q MAX_VIDEO_QUALITY, --max-video-quality MAX_VIDEO_QUALITY
-                        Use best available video resolution up to this height in pixels. Example: "360" for maximum height 360p. Get the highest available resolution by default.
+  -q MAX_VIDEO_WIDTH, --max-video-width MAX_VIDEO_WIDTH
+                        Use best available video resolution up to this width in pixels. Example: "360" for maximum width of 360p. Get the highest available resolution by default.
   -o OUTPUT_DIR, --output-dir OUTPUT_DIR
                         Output directory where to write downloaded chunks. (Default: CWD)
   -d, --delete-source   Delete source files once final merge has been done. (default: False)

--- a/README.md
+++ b/README.md
@@ -3,20 +3,20 @@
 
 Cookies (in Netscape format) are needed to access membership-only videos as well as age-restricted videos (which would also mean that you sold your soul to Youtube and your account is "verified"). You may use [this](https://github.com/hrdl-github/cookies-txt) or [that](https://github.com/dandv/convert-chrome-cookies-to-netscape-format) depending on the browser you used to log into that dis-service.
 
-The example files from the `/config` directory should be copied to `$HOME/.config/livestream_saver/` and updated manually:
+The example files from the `config` directory should be copied to `$HOME/.config/livestream_saver/` and updated manually:
 * `livestream_saver.cfg`
 * `ytdlp_config.json`
 * `.env`
 
 
 > [!IMPORTANT]
-> The download feature is currently half-broken (see issue [#63](https://github.com/glubsy/livestream_saver/issues/63)) so we rely on yt-dlp for the time being.
+> `yt-dlp` is now used to probe livestream metadata and available formats before downloading.
 > 
-> As a result, many native configuration settings from the config file and CLI arguments (and some hooks) are **ignored**.
+> By default, the project still uses its native downloader to fetch segments, but you can opt into using `yt-dlp` as the downloader as well with the `use_ytdl` setting from the config file.
 > 
-> The `ytdlp_config.json` file holds the default options passed to yt-dlp as defined in their [Readme.md](https://github.com/yt-dlp/yt-dlp#embedding-examples). It should be placed in `$HOME/.config/livestream_saver/ytdlp_config.json` and edited, otherwise the default provided template will be used as fallback.
+> The `ytdlp_config.json` file holds the default options passed to `yt-dlp` as defined in their [Readme.md](https://github.com/yt-dlp/yt-dlp#embedding-examples). It should be placed in `$HOME/.config/livestream_saver/ytdlp_config.json` and edited, otherwise the default provided template will be used as fallback.
 > 
-> This is confusing but may be improved eventually once we remove yt-dlp as the downloader.
+> Some `yt-dlp` options are intentionally ignored during probing, such as format-selection settings, because livestream_saver performs its own format selection after collecting the full list of available formats.
 
 # Monitoring a channel
 
@@ -169,9 +169,9 @@ pip3 install .[pot]
 
 ## Docker container
 
-If you prefer to build and use a Docker container, look at the Readme inside the `docker` directory.
+If you prefer to build and use a container image, look at the Readme inside the `docker` directory.
 
-Docker image also available at https://hub.docker.com/r/glubsy/livestream_saver (can also be referenced in docker-compose)
+A prebuilt Docker image is available at https://hub.docker.com/r/glubsy/livestream_saver (it can be referenced in docker-compose also)
 
 # Configuration
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ optional arguments:
 * python >= 3.10
 * yt-dlp (preferrably always the latest version)
 * (optional) some [POT provider](https://github.com/Brainicism/bgutil-ytdlp-pot-provider)
+* (optional) `bgutil-ytdlp-pot-provider` yt-dlp plugin to talk to an external POT provider
+* (optional) `yt-dlp-ejs` for enhanced yt-dlp extraction support
 * [pytube](https://github.com/pytube/pytube) 10.9.2
 * ffmpeg (and ffprobe) to concatenate segments and merge them into one file 
 * [Pillow](https://pillow.readthedocs.io/en/stable/installation.html) (optional) to convert webp thumbnail
@@ -149,6 +151,18 @@ optional arguments:
 python3 -m venv venv  # or virtualenv -p python3 venv
 source ./venv/bin/activate
 pip3 install -r requirements.txt
+```
+
+* If you want more reliable extraction support for yt-dlp, install the optional dependencies as well (recommended):
+
+```
+pip3 install -r requirements-opt.txt
+```
+
+* If you install from the Python package metadata instead, the optional POT-related extras are available with:
+
+```
+pip3 install .[pot]
 ```
 
 * If you don't want to use a venv (to avoid having to activate the venv everytime you need to start the program, with `source /path/to/venv/bin/activate`), you *could* install dependencies system-wide. Remember to use `sudo pip3` then.

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ optional arguments:
 
 * python >= 3.10
 * yt-dlp (preferrably always the latest version)
+* (optional) some [POT provider](https://github.com/Brainicism/bgutil-ytdlp-pot-provider)
 * [pytube](https://github.com/pytube/pytube) 10.9.2
 * ffmpeg (and ffprobe) to concatenate segments and merge them into one file 
 * [Pillow](https://pillow.readthedocs.io/en/stable/installation.html) (optional) to convert webp thumbnail

--- a/config/livestream_saver.cfg
+++ b/config/livestream_saver.cfg
@@ -69,7 +69,7 @@ ytdlp_command = yt-dlp
 	%VIDEO_URL%
 
 # Path to cookies that can be re-used in individual sections:
-# cookies = 
+# cookies = ${DEFAULT:cookies}
 
 
 [webhook]

--- a/config/livestream_saver.cfg
+++ b/config/livestream_saver.cfg
@@ -22,6 +22,13 @@
 # segments merge step. 
 # ignore_quality_change = False
 
+# Specify the maximum height resolution to download
+max_video_width = 480
+
+# Let yt-dlp perform the actual download instead of the built-in downloader.
+# When false, yt-dlp is only used to probe stream information.
+use_ytdl = False
+
 
 [env]
 # This special section may hold key value pairs found among the environment variables.
@@ -170,15 +177,23 @@ on_merge_done_command_logged = false
 # This can be used in any section to skip downloading anything.
 # skip_download = True
 
+# Use yt-dlp as downloader instead of the built-in segment downloader.
+# use_ytdl = ${DEFAULT:use_ytdl}
+
 
 [download]
 # These values are only loaded in Download mode.
 
 log_level = WARNING
+
 # If live has not started yet, delay retrying by this many minutes.
 scan_delay = 2.5
+
 # Path to Netscape formatted cookies file.
 # cookies = /path/to/cookies.txt
+
+# Use yt-dlp as downloader instead of the built-in segment downloader.
+# use_ytdl = ${DEFAULT:use_ytdl}
 
 # This triggers when a download is pending and waiting for a livestream to start.
 on_download_initiated_command = ${common:ytdlp_command}

--- a/config/livestream_saver.cfg
+++ b/config/livestream_saver.cfg
@@ -101,8 +101,10 @@ webhook_data_live = '{
 # These values are only loaded in Monitor mode.
 
 log_level = INFO
+
 # Delay between scan retries in minutes
 scan_delay = 15.5
+
 # Path to Netscape formatted cookies file.
 # cookies = /path/to/cookies.txt
 
@@ -234,12 +236,13 @@ channel_name = Kamiko Kana
 scan_delay = 20.0
 URL = https://www.youtube.com/c/kamikokana
 
-[monitor elfinpsyop]
-channel_name = elfinpsyop
+[monitor Muyu]
+channel_name = Muyu
 scan_delay = 20.0
-URL = https://www.youtube.com/@elfinpsyop
+URL = https://www.youtube.com/@MuuMuyu
 # allow_regex = ".*archiv.*|.*karaoke.*|.*sing.*"
 block_regex = ""
+max_video_width = ${DEFAULT:max_video_width}
 
 [monitor Saba]
 # These values only apply to monitor mode.

--- a/config/ytdlp_config.json
+++ b/config/ytdlp_config.json
@@ -1,4 +1,6 @@
 {
+    // "verbose": true,
+
     // Stream selection format.
     // For example "134+140/mp4+m4a/bestvideo+bestaudio"
     // would prefer 360p video + AAC 128kpbs audio to be muxed with ffmpeg,
@@ -27,7 +29,10 @@
 
     // "wait_for_video": (60, 120),
 
-    "live_from_start": true,
+    // A bug prevents us from using yt-dlp reliably for live streams when passing
+    // this option, so we will use the built-in downloader instead.
+    // See: https://github.com/yt-dlp/yt-dlp/issues/15274
+    // "live_from_start": true,
 
     "writethumbnail": true,
 
@@ -35,6 +40,8 @@
 
     // Abort download if some fragments are unavailable, we will retry
     "abort-on-unavailable-fragments": true,
+
+    // "wait_for_video" = (60, 120),
 
     "postprocessors": [
         {

--- a/docker/Containerfile
+++ b/docker/Containerfile
@@ -7,24 +7,13 @@ COPY --from=deno-bin /deno /usr/local/bin/deno
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ffmpeg \
-        git \
     && rm -rf /var/lib/apt/lists/*
-
-ENV PATH="/root/.deno/bin:${PATH}"
-
-RUN git init /opt/bgutil-ytdlp-pot-provider \
-    && cd /opt/bgutil-ytdlp-pot-provider \
-    && git remote add origin https://github.com/Brainicism/bgutil-ytdlp-pot-provider.git \
-    && git fetch --depth 1 origin 6b497de5a6cbaf106bd94a934c5d2794c3fdf8bb \
-    && git checkout FETCH_HEAD \
-    && cd ./server \
-    && deno install --allow-scripts=npm:canvas --frozen \
-    && rm -rf .git
 
 WORKDIR /app
 
 COPY requirements.txt ./
-RUN pip install --no-cache-dir -r requirements.txt
+COPY requirements-opt.txt ./
+RUN pip install --no-cache-dir -r requirements-opt.txt
 
 COPY "./livestream_saver/" ./livestream_saver/
 COPY "livestream_saver.py" .

--- a/docker/Containerfile
+++ b/docker/Containerfile
@@ -7,7 +7,19 @@ COPY --from=deno-bin /deno /usr/local/bin/deno
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ffmpeg \
+        git \
     && rm -rf /var/lib/apt/lists/*
+
+ENV PATH="/root/.deno/bin:${PATH}"
+
+RUN git init /opt/bgutil-ytdlp-pot-provider \
+    && cd /opt/bgutil-ytdlp-pot-provider \
+    && git remote add origin https://github.com/Brainicism/bgutil-ytdlp-pot-provider.git \
+    && git fetch --depth 1 origin 6b497de5a6cbaf106bd94a934c5d2794c3fdf8bb \
+    && git checkout FETCH_HEAD \
+    && cd ./server \
+    && deno install --allow-scripts=npm:canvas --frozen \
+    && rm -rf .git
 
 WORKDIR /app
 

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -67,6 +67,16 @@ Edit the `docker-compose.yml` file, create the download directory and point to i
 docker-compose -f ./docker/compose.yaml --env-file "$(echo $HOME)/.config/livestream_saver/.env" up 
 ```
 
+## Podman
+
+If you use Podman and the default rootless networking causes issues with the POT provider service, use the Podman override file:
+
+```sh
+podman-compose -f ./docker/compose.yaml -f ./docker/compose.podman.yaml --env-file "$(echo $HOME)/.config/livestream_saver/.env" up
+```
+
+This override switches the services to host networking and points the downloader containers to the POT provider at `http://127.0.0.1:4416`.
+
 # Maintainer notes
 
 As a memo, to push a new image to Docker Hub:

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -76,6 +76,7 @@ podman-compose -f ./docker/compose.yaml -f ./docker/compose.podman.yaml --env-fi
 ```
 
 This override switches the services to host networking and points the downloader containers to the POT provider at `http://127.0.0.1:4416`.
+It also disables TTY allocation for the downloader services so segment progress is printed as normal log lines instead of carriage-return updates, which `podman-compose` does not render reliably.
 
 # Maintainer notes
 

--- a/docker/Readme.md
+++ b/docker/Readme.md
@@ -10,6 +10,16 @@ podman build -f ./docker/Containerfile -t livestream_saver:latest -t livestream_
 
 For a quick local development loop, use [`dev.sh`](./dev.sh). It builds the image and then prompts for either a channel URL or a config section name before starting `monitor <url>` or `monitor -s <section>` in the `testing` tag with your config directory, `downloads` volume, and host networking.
 
+# POT provider dependency
+
+This project now expects the [bgutil-ytdlp POT provider](https://github.com/Brainicism/bgutil-ytdlp-pot-provider) to run separately from the downloader container.
+
+- If you use `docker compose`, the provider is started automatically as the `pot-provider` service.
+- If you run the downloader container manually, you must start the POT provider yourself before starting the downloader container.
+
+The downloader container reads the provider URL from `LSS_POT_PROVIDER_URL` and injects it into the `yt-dlp` extractor arguments automatically.
+The Docker image installs the optional POT-related Python dependencies from `requirements-pot.txt`.
+
 # Run in a container:
 
 * Create a config directory, like `$HOME/.config/livestream_saver` and copy the following files into it (or make hard links):
@@ -21,8 +31,19 @@ For a quick local development loop, use [`dev.sh`](./dev.sh). It builds the imag
 Then you can mount that directory inside the container as `/root/.config/livestream_saver`.
 Don't forget to mount your `downloads` directory where both logs and data will be output.
 
+Before starting the downloader container manually, start the POT provider container.
+One simple option is:
+
+```sh
+docker run --rm -d --net=host --name bgutil-pot-provider -p 4416:4416 brainicism/bgutil-ytdlp-pot-provider:latest
+```
+
+Then point the downloader container at it with `LSS_POT_PROVIDER_URL`.
+If the provider is published on the same Docker host, a common value is `http://host.docker.internal:4416`.
+On Linux, if `host.docker.internal` is not available in your Docker setup, use the Docker host IP instead or run both containers on the same user-defined Docker network.
+
 ```docker
-docker run --rm --mount type=bind,src="$(echo $HOME)/.config/livestream_saver",target="/root/.config/livestream_saver" --mount type=bind,src="./downloads",target="/downloads" --env-file="$(echo $HOME)/.config/livestream_saver/.env" livestream_saver:latest monitor https://www.youtube.com/@Gura
+docker run --rm --mount type=bind,src="$(echo $HOME)/.config/livestream_saver",target="/root/.config/livestream_saver" --mount type=bind,src="./downloads",target="/downloads" --env-file="$(echo $HOME)/.config/livestream_saver/.env" -e LSS_POT_PROVIDER_URL="http://host.docker.internal:4416" --network=host livestream_saver:latest monitor https://www.youtube.com/@Gura
 ```
 
 WARNING: it is best to comment out all `cookies` values in your `livestream_saver.cfg` file. A single path is already provided from the `LSS_COOKIES_FILE` environment variable! 
@@ -34,12 +55,12 @@ Although, you could still specify and use these values if you really wanted to, 
 By default `monitor` mode is called but you can specify your own command when running the container:
 
 ```docker
-docker run --rm  --mount type=bind,src="$(echo $HOME)/.config/livestream_saver",target="/root/.config/livestream_saver" --mount type=bind,src="./downloads",target="/downloads" --env-file="$(echo $HOME)/.config/livestream_saver/.env" livestream_saver:latest download <URL> 
+docker run --rm  --mount type=bind,src="$(echo $HOME)/.config/livestream_saver",target="/root/.config/livestream_saver" --mount type=bind,src="./downloads",target="/downloads" --env-file="$(echo $HOME)/.config/livestream_saver/.env" -e LSS_POT_PROVIDER_URL="http://host.docker.internal:4416" --network=host livestream_saver:latest download <URL> 
 ```
 
 # Run multiple containers
 
-Docker compose is useful to spawn multiple containers at once, one container per monitored channel.
+Docker compose is useful to spawn multiple containers at once, one container per monitored channel, plus a shared POT provider service.
 Edit the `docker-compose.yml` file, create the download directory and point to it, then run:
 
 ```
@@ -54,6 +75,11 @@ As a memo, to push a new image to Docker Hub:
 VERSION=$(sed -n 's/^version = "\(.*\)"/\1/p' pyproject.toml)
 podman push localhost/livestream_saver:$VERSION docker://docker.io/glubsy/livestream_saver:$VERSION
 podman push localhost/livestream_saver:latest docker://docker.io/glubsy/livestream_saver:latest
+```
+
+Inspect an image with
+```sh
+dive --source podman localhost/livestream_saver:latest
 ```
 
 GitHub Actions now handles this automatically from `.github/workflows/docker-publish.yml`.

--- a/docker/compose.podman.yaml
+++ b/docker/compose.podman.yaml
@@ -1,0 +1,28 @@
+services:
+  pot-provider:
+    network_mode: host
+
+  Panko:
+    network_mode: host
+    environment:
+      LSS_POT_PROVIDER_URL: http://127.0.0.1:4416
+
+  Bijou:
+    network_mode: host
+    environment:
+      LSS_POT_PROVIDER_URL: http://127.0.0.1:4416
+
+  Fuwamoco:
+    network_mode: host
+    environment:
+      LSS_POT_PROVIDER_URL: http://127.0.0.1:4416
+
+  Prune:
+    network_mode: host
+    environment:
+      LSS_POT_PROVIDER_URL: http://127.0.0.1:4416
+
+  Saba:
+    network_mode: host
+    environment:
+      LSS_POT_PROVIDER_URL: http://127.0.0.1:4416

--- a/docker/compose.podman.yaml
+++ b/docker/compose.podman.yaml
@@ -1,28 +1,45 @@
 services:
   pot-provider:
+    # Rootless Podman networking may fail with the default Compose setup
+    # because podman-compose can rely on pasta/tun. Host networking avoids
+    # those issues for the standalone POT provider HTTP service.
     network_mode: host
 
   Panko:
+    # Disable TTY so download progress is printed as normal lines instead
+    # of carriage-return updates, which podman-compose does not render well.
+    tty: false
+    stdin_open: false
+    # With host networking, the downloader must reach the shared POT
+    # provider via localhost instead of the Compose service name.
     network_mode: host
     environment:
       LSS_POT_PROVIDER_URL: http://127.0.0.1:4416
 
   Bijou:
+    tty: false
+    stdin_open: false
     network_mode: host
     environment:
       LSS_POT_PROVIDER_URL: http://127.0.0.1:4416
 
   Fuwamoco:
+    tty: false
+    stdin_open: false
     network_mode: host
     environment:
       LSS_POT_PROVIDER_URL: http://127.0.0.1:4416
 
   Prune:
+    tty: false
+    stdin_open: false
     network_mode: host
     environment:
       LSS_POT_PROVIDER_URL: http://127.0.0.1:4416
 
   Saba:
+    tty: false
+    stdin_open: false
     network_mode: host
     environment:
       LSS_POT_PROVIDER_URL: http://127.0.0.1:4416

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -17,6 +17,7 @@ x-defaults:
       condition: service_started
   environment:
     LSS_POT_PROVIDER_URL: http://pot-provider:4416
+    LSS_COOKIES_FILE: /root/.config/livestream_saver/cookies.txt
   volumes:
     - type: bind
       # This path is relative to this here file

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -12,6 +12,11 @@ x-defaults:
   init: true
   tty: true         # interactive terminal for carriage-return progress updates
   stdin_open: true  # keep stdin open
+  depends_on:
+    pot-provider:
+      condition: service_started
+  environment:
+    LSS_POT_PROVIDER_URL: http://pot-provider:4416
   volumes:
     - type: bind
       # This path is relative to this here file
@@ -22,6 +27,10 @@ x-defaults:
       target: /root/.config/livestream_saver
 
 services:
+  pot-provider:
+    image: brainicism/bgutil-ytdlp-pot-provider:latest
+    restart: always
+
   # Each service defines monitoring of a Youtube channel
   # Here are some examples provided by default
   Panko:

--- a/docker/compose.yaml
+++ b/docker/compose.yaml
@@ -10,6 +10,8 @@ x-defaults:
   restart: always
   # to upgrade yt-dlp on every container start
   init: true
+  tty: true         # interactive terminal for carriage-return progress updates
+  stdin_open: true  # keep stdin open
   volumes:
     - type: bind
       # This path is relative to this here file

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,4 +4,8 @@ set -e
 # echo "Upgrading yt-dlp to the latest version..."
 # pip install --upgrade --no-cache-dir yt-dlp
 
+cd /opt/bgutil-ytdlp-pot-provider/server/node_modules
+deno run --allow-env --allow-net --allow-ffi=. --allow-read=. ../src/main.ts &
+
+cd /app
 exec python ./livestream_saver.py "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,8 +4,5 @@ set -e
 # echo "Upgrading yt-dlp to the latest version..."
 # pip install --upgrade --no-cache-dir yt-dlp
 
-cd /opt/bgutil-ytdlp-pot-provider/server/node_modules
-deno run --allow-env --allow-net --allow-ffi=. --allow-read=. ../src/main.ts &
-
 cd /app
 exec python ./livestream_saver.py "$@"

--- a/livestream_saver/cookies.py
+++ b/livestream_saver/cookies.py
@@ -61,7 +61,7 @@ Using blank cookie jar.")
         cj.filename = cp_str  # this has to be an absolute valid path string
         return cj
 
-    new_cp_str = str(Path(cookiefile_path).absolute().with_suffix('')) + "_updated.txt"
+    new_cp_str = str(cp.absolute().with_suffix('')) + "_updated.txt"
     new_cp = Path(new_cp_str)
 
     try:

--- a/livestream_saver/download.py
+++ b/livestream_saver/download.py
@@ -243,7 +243,7 @@ class YoutubeLiveStream:
         session: YoutubeUrllibSession,
         notifier: NotificationDispatcher,
         url: Optional[str] = None,
-        max_video_quality: Optional[str] = None,
+        max_video_width: Optional[str] = None,
         output_dir: Optional[Path] = None,
         hooks: Dict = {},
         skip_download = False,
@@ -257,7 +257,7 @@ class YoutubeLiveStream:
         self.session = session
         self.video_id = video_id
         self.url = url if url else f"https://www.youtube.com/watch?v={video_id}"
-        self.max_video_quality = max_video_quality
+        self.max_video_width = max_video_width
 
         self._js: Optional[str] = None  # js fetched by js_url
         self._js_url: Optional[str] = None  # the url to the js, parsed from watch html
@@ -1102,7 +1102,7 @@ class YoutubeLiveStream:
             self.log.info("Forcing update of download URLs.")
 
         video_quality, audio_quality = self.get_best_streams(
-            maxq=self.max_video_quality, log=not force)
+            maxq=self.max_video_width, log=not force)
 
         if not force:
             # Most likely first time

--- a/livestream_saver/download.py
+++ b/livestream_saver/download.py
@@ -2,7 +2,7 @@
 import json
 from typing import Optional, Dict, List, Any
 from os import sep, path, makedirs, listdir
-from sys import stderr
+from sys import stderr, stdout
 from platform import system
 import logging
 from datetime import date, datetime, timezone
@@ -1760,16 +1760,20 @@ class YoutubeLiveStream:
     def print_progress(self, seg: int) -> None:
         # TODO display rotating wheel in interactive mode
         fullmsg = f"Downloading segment {seg}..."
-        if ISWINDOWS:
-            prev_len = getattr(self, '_report_progress_prev_line_length', 0)
-            if prev_len > len(fullmsg):
-                fullmsg += ' ' * (prev_len - len(fullmsg))
-            self._report_progress_prev_line_length = len(fullmsg)
-            clear_line = '\r'
-        else:
-            clear_line = ('\r\x1b[K' if stderr.isatty() else '\r')
+        if stdout.isatty():
+            if ISWINDOWS:
+                prev_len = getattr(self, '_report_progress_prev_line_length', 0)
+                if prev_len > len(fullmsg):
+                    fullmsg += ' ' * (prev_len - len(fullmsg))
+                self._report_progress_prev_line_length = len(fullmsg)
+                clear_line = '\r'
+            else:
+                clear_line = ('\r\x1b[K' if stderr.isatty() else '\r')
 
-        print(clear_line + fullmsg, end='')
+            print(clear_line + fullmsg, end='', flush=True)
+        else:
+            print(fullmsg, flush=True)
+
         self.log.debug(fullmsg)
 
     # OBSOLETE

--- a/livestream_saver/download.py
+++ b/livestream_saver/download.py
@@ -12,7 +12,8 @@ from contextlib import closing
 from enum import Flag, auto
 from pathlib import Path
 import re
-from urllib.request import urlopen
+from urllib.request import urlopen, Request
+from urllib.parse import urljoin
 import urllib.error
 from http.client import IncompleteRead
 import xml.etree.ElementTree as ET
@@ -21,6 +22,7 @@ import yt_dlp
 
 import pytube.cipher
 import pytube
+from copy import deepcopy
 
 from livestream_saver.notifier import NotificationDispatcher
 from livestream_saver.request import YoutubeUrllibSession
@@ -298,6 +300,7 @@ class YoutubeLiveStream:
 
         self.video_base_url = None
         self.audio_base_url = None
+        self.is_muxed_hls = False
         self.seg = 0
         self.seg_attempt = 0
         self.status = Status.OFFLINE
@@ -334,6 +337,16 @@ class YoutubeLiveStream:
 
         self.allow_regex: Optional[re.Pattern] = filters.get("allow_regex")
         self.block_regex: Optional[re.Pattern] = filters.get("block_regex")
+
+    def get_ytdl_info_opts(self) -> Dict[str, Any]:
+        """Return yt-dlp options suitable for probing all available formats."""
+        opts = deepcopy(self.ytdl_opts) if self.ytdl_opts else {}
+
+        # We want the full formats list here and do our own selection later.
+        for key in ("format", "format_sort"):
+            opts.pop(key, None)
+
+        return opts
 
     def setup_logger(self, output_path: Path, log_level: str | int):
         if isinstance(log_level, str):
@@ -917,18 +930,29 @@ class YoutubeLiveStream:
             except Exception as e:
                 self.log.warning(f"Error writing thumbnails: {e}")
 
+    @staticmethod
+    def _stream_value(stream: Any, key: str) -> Any:
+        if stream is None:
+            return None
+        if isinstance(stream, dict):
+            if key == "itag":
+                return stream.get("format_id") or stream.get("itag")
+            if key == "resolution":
+                if height := stream.get("height"):
+                    return f"{height}p"
+                return stream.get("resolution")
+            if key == "abr":
+                return stream.get("abr")
+            if key == "mime_type":
+                return stream.get("ext") or stream.get("protocol")
+            return stream.get(key)
+        return getattr(stream, key, None)
+
     def update_metadata(self):
         """
         Write some basic metadata to a file and download thumbnail onto storage
         device.
         """
-        if self.video_itag:
-            if info := pytube.itags.ITAGS.get(self.video_itag):
-                self.video_resolution = info[0]
-        if self.audio_itag:
-            if info := pytube.itags.ITAGS.get(self.audio_itag):
-                self.audio_bitrate = info[0]
-
         self.download_thumbnail()
 
         # TODO get the description once the stream has started
@@ -962,11 +986,11 @@ class YoutubeLiveStream:
             ).__str__()
 
         if self.video_itag:
-            info["video_itag"] = self.video_itag.itag
-            info["video_resolution"] = self.video_itag.resolution
+            info["video_itag"] = self._stream_value(self.video_itag, "itag")
+            info["video_resolution"] = self._stream_value(self.video_itag, "resolution")
         if self.audio_itag:
-            info["audio_itag"] = self.audio_itag.itag
-            info["audio_bitrate"] = self.audio_itag.abr
+            info["audio_itag"] = self._stream_value(self.audio_itag, "itag")
+            info["audio_bitrate"] = self._stream_value(self.audio_itag, "abr")
         return info
 
     def update_status(self):
@@ -1132,13 +1156,31 @@ class YoutubeLiveStream:
 
 
     def download(self, wait_delay: float = 1.0):
+        with yt_dlp.YoutubeDL(self.get_ytdl_info_opts()) as ydl:
+            info = ydl.extract_info(self.url, download=False)
+            # sanitize_info makes the info json-serializable
+            # print(json.dumps(ydl.sanitize_info(info)))
 
         if self.use_ytdl:
             with yt_dlp.YoutubeDL(self.ytdl_opts) as ydl:
-                # info = ydl.extract_info(self.url, download=False)
-                # sanitize_info makes the info json-serializable
-                # print(json.dumps(ydl.sanitize_info(info)))
                 self.error = ydl.download(self.url)
+            return
+
+        if self.prepare_hls_download(info):
+            self.update_metadata()
+            self.trigger_hooks('on_download_started')
+
+            if self.skip_download:
+                self.done = True
+                return
+
+            self.do_download_hls(wait_delay=wait_delay)
+            if self.done:
+                self.log.info(f"Finished downloading {self.video_id}.")
+                self.trigger_hooks("on_download_ended")
+            if self.error:
+                self.log.critical(
+                    f"Some kind of error occured during download? {self.error}")
             return
 
         # If one of the directories exists, assume we are resuming a previously
@@ -1261,6 +1303,237 @@ class YoutubeLiveStream:
             self.trigger_hooks("on_download_ended")
         if self.error:
             self.log.critical(f"Some kind of error occured during download? {self.error}")
+
+    def prepare_hls_download(self, info: Optional[Dict[str, Any]]) -> bool:
+        if not info:
+            return False
+
+        selected = self.get_best_hls_format(info)
+        if not selected:
+            return False
+
+        self.video_itag = selected
+        self.audio_itag = None
+        self.video_base_url = selected.get("url") or selected.get("manifest_url")
+        self.audio_base_url = None
+        self.is_muxed_hls = True
+
+        if not self.video_base_url:
+            self.log.warning("Selected HLS format had no playlist URL.")
+            self.is_muxed_hls = False
+            return False
+
+        dir_existed = False
+        try:
+            makedirs(self.video_outpath, 0o770)
+        except FileExistsError:
+            dir_existed = True
+
+        if dir_existed:
+            self.seg = self.get_first_segment((self.video_outpath,))
+        else:
+            self.seg = 0
+
+        self.log.info(
+            "Selected muxed HLS itag %s at %s via yt-dlp.",
+            self._stream_value(selected, "itag"),
+            self._stream_value(selected, "resolution"),
+        )
+        self.log.info(f"Will start downloading from segment number {self.seg}.")
+        return True
+
+    def get_best_hls_format(self, info: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        formats = info.get("formats") or []
+        if not isinstance(formats, list):
+            return None
+
+        maxq = self.max_video_width
+        if maxq is not None and not isinstance(maxq, int):
+            match = re.search(r"(\d{3,4})", str(maxq))
+            maxq = int(match.group(1)) if match else None
+
+        candidates = [
+            fmt for fmt in formats
+            if isinstance(fmt, dict)
+            and fmt.get("protocol") == "m3u8_native"
+            and fmt.get("vcodec") not in (None, "none")
+            and fmt.get("acodec") not in (None, "none")
+            and (fmt.get("url") or fmt.get("manifest_url"))
+        ]
+        if not candidates:
+            return None
+
+        if maxq is not None:
+            within_limit = [
+                fmt for fmt in candidates
+                if isinstance(fmt.get("height"), int) and fmt["height"] <= maxq
+            ]
+            if within_limit:
+                candidates = within_limit
+
+        return sorted(
+            candidates,
+            key=lambda fmt: (fmt.get("height") or -1, fmt.get("tbr") or -1),
+            reverse=True
+        )[0]
+
+    def refresh_hls_format(self) -> None:
+        with yt_dlp.YoutubeDL(self.get_ytdl_info_opts()) as ydl:
+            info = ydl.extract_info(self.url, download=False)
+
+        selected = self.get_best_hls_format(info)
+        if not selected:
+            raise Exception("Failed to refresh muxed HLS format from yt-dlp.")
+
+        if self.video_itag and \
+        self._stream_value(self.video_itag, "itag") != self._stream_value(selected, "itag"):
+            self.log.warning(
+                "Muxed HLS itag changed from %s to %s while refreshing.",
+                self._stream_value(self.video_itag, "itag"),
+                self._stream_value(selected, "itag"),
+            )
+
+        self.video_itag = selected
+        self.video_base_url = selected.get("url") or selected.get("manifest_url")
+
+    def make_request_obj(
+        self,
+        url: str,
+        extra_headers: Optional[Dict[str, str]] = None
+    ) -> Request:
+        headers = self.session.headers.copy()
+        if extra_headers:
+            headers.update(extra_headers)
+        req = Request(url, headers=headers)
+        self.session.cookie_jar.add_cookie_header(req)
+        return req
+
+    def get_hls_playlist_segments(
+        self,
+        playlist_url: str,
+        extra_headers: Optional[Dict[str, str]] = None
+    ) -> tuple[List[tuple[int, str]], bool]:
+        req = self.make_request_obj(playlist_url, extra_headers=extra_headers)
+        content = self.session.get_response_as_str(req)
+
+        media_sequence = 0
+        end_list = False
+        segments: List[tuple[int, str]] = []
+        seg_num: Optional[int] = None
+
+        for raw_line in content.splitlines():
+            line = raw_line.strip()
+            if not line:
+                continue
+            if line.startswith("#EXT-X-MEDIA-SEQUENCE:"):
+                media_sequence = int(line.rsplit(":", 1)[-1])
+                seg_num = media_sequence
+                continue
+            if line == "#EXT-X-ENDLIST":
+                end_list = True
+                continue
+            if line.startswith("#"):
+                continue
+
+            if seg_num is None:
+                seg_num = media_sequence
+            segments.append((seg_num, urljoin(playlist_url, line)))
+            seg_num += 1
+
+        return segments, end_list
+
+    def download_hls_segment(
+        self,
+        segment_url: str,
+        seg_num: int,
+        stream_type: str = "video",
+        extra_headers: Optional[Dict[str, str]] = None
+    ) -> bool:
+        segment_filename = f'{self.video_outpath}{sep}{seg_num:0{10}}_video.ts'
+        req = self.make_request_obj(segment_url, extra_headers=extra_headers)
+
+        with closing(urlopen(req)) as in_stream:
+            headers = in_stream.headers
+            status = in_stream.status
+            if status >= 204:
+                self.log.debug(f"Seg {seg_num} {stream_type} URL: {segment_url}")
+                self.log.debug(f"Seg status: {status}")
+                self.log.debug(f"Seg headers:\n{headers}")
+
+            if not self.write_to_file(in_stream, segment_filename):
+                if status == 204 and headers.get('X-Segment-Lmt', "0") == "0":
+                    raise EmptySegmentException(
+                        f"Segment {seg_num} ({stream_type}) is empty, stream might have ended...")
+                return False
+        return True
+
+    def do_download_hls(self, wait_delay: float = 1.0):
+        if not self.video_base_url:
+            raise Exception("Missing HLS playlist url!")
+
+        wait_sec = max(1, round(wait_delay))
+        last_refresh_time = datetime.now()
+
+        while not self.done and not self.error:
+            try:
+                now = datetime.now()
+                if (now - last_refresh_time).total_seconds() > 5 * 60:
+                    self.refresh_hls_format()
+                    last_refresh_time = now
+
+                extra_headers = self.video_itag.get("http_headers") \
+                    if isinstance(self.video_itag, dict) else None
+                segments, end_list = self.get_hls_playlist_segments(
+                    self.video_base_url,
+                    extra_headers=extra_headers
+                )
+                next_segments = [
+                    (seg_num, seg_url)
+                    for seg_num, seg_url in segments
+                    if seg_num >= self.seg
+                ]
+
+                if not next_segments:
+                    if end_list:
+                        self.done = True
+                        break
+                    sleep(wait_sec)
+                    continue
+
+                for seg_num, seg_url in next_segments:
+                    self.print_progress(seg_num)
+                    if not self.download_hls_segment(
+                        seg_url,
+                        seg_num,
+                        extra_headers=extra_headers
+                    ):
+                        break
+                    self.seg = seg_num + 1
+
+                if end_list and self.seg > next_segments[-1][0]:
+                    self.done = True
+                    break
+
+            except (
+                EmptySegmentException,
+                ForbiddenSegmentException,
+                IncompleteRead,
+                ValueError,
+                ConnectionError,
+                urllib.error.HTTPError,
+                urllib.error.URLError
+            ) as e:
+                self.log.warning(e)
+                try:
+                    self.refresh_hls_format()
+                except Exception as refresh_err:
+                    self.error = f"{refresh_err}"
+                    break
+                sleep(wait_sec)
+            except Exception as e:
+                self.log.exception("Unhandled exception in HLS download. Aborting.")
+                self.error = f"{e}"
+                break
 
     def download_seg(self, baseurl: BaseURL, seg, type):
         segment_url: str = baseurl.add_seg(seg)

--- a/livestream_saver/download.py
+++ b/livestream_saver/download.py
@@ -369,7 +369,7 @@ class YoutubeLiveStream:
             return
 
         if not self._title:
-            self._title = info.get("title") or info.get("fulltitle")
+            self._title = info.get("fulltitle") or info.get("title")
         if not self._author:
             self._author = info.get("channel") or info.get("uploader")
         if not self._description:

--- a/livestream_saver/download.py
+++ b/livestream_saver/download.py
@@ -357,8 +357,8 @@ class YoutubeLiveStream:
         try:
             with yt_dlp.YoutubeDL(self.get_ytdl_info_opts()) as ydl:
                 self._ytdlp_info = ydl.extract_info(self.url, download=False)
-        except Exception as e:
-            self.log.debug(f"Error getting metadata from yt-dlp: {e}")
+        except Exception as exc:
+            self.log.debug("Error getting metadata from yt-dlp: %s", exc)
             return self._ytdlp_info
 
         self.hydrate_metadata_from_ytdlp_info(self._ytdlp_info)
@@ -465,9 +465,9 @@ class YoutubeLiveStream:
         try:
             title = self.title
             description = self.description
-        except Exception as e:
+        except Exception as exc:
             # Default to allowing download in that case.
-            self.log.error(f"Failed getting some metadata for regex matching: {e}")
+            self.log.error("Failed getting some metadata for regex matching: %s", exc)
 
         # Fallback to using data from monitoring phase
         if not title and self._initial_metadata is not None:
@@ -515,28 +515,28 @@ class YoutubeLiveStream:
             except (
                 NoLoginException,
                 UnplayableException
-            ) as e:
-                self.log.warning(e)
+            ) as exc:
+                self.log.warning(exc)
                 if not (Status.LIVE in self.status):
                     self.log.info("Stream is not live anymore.")
                     break
                 wait_block(long_wait)
                 continue
-            except OutdatedAppException as e:
-                self.log.warning(f"Outdated client error. Retrying shortly...")
+            except OutdatedAppException as exc:
+                self.log.warning("Outdated client error. Retrying shortly...")
                 if not (Status.LIVE in self.status):
                     self.log.info("Stream is not live anymore.")
                     break
                 wait_block(2)
                 continue
-            except Exception as e:
-                self.log.error(f"Error getting status for stream {self.video_id}: {e}")
+            except Exception as exc:
+                self.log.error("Error getting status for stream %s: %s", self.video_id, exc)
 
             if not self.status == Status.OK:
-                self.log.info(f"Stream {self.video_id} status is not active.")
+                self.log.info("Stream %s status is not active.", self.video_id)
                 break
 
-            self.log.info(f"Stream {self.video_id} is still active...")
+            self.log.info("Stream %s is still active...", self.video_id)
 
             # Keep checking in case the metadata changed
             self.get_ytdlp_info(force_update=True)

--- a/livestream_saver/download.py
+++ b/livestream_saver/download.py
@@ -5,7 +5,7 @@ from os import sep, path, makedirs, listdir
 from sys import stderr
 from platform import system
 import logging
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from time import time, sleep
 from json import dumps, dump, loads
 from contextlib import closing
@@ -280,8 +280,10 @@ class YoutubeLiveStream:
         self._author: Optional[str] = None
         self._title: Optional[str] = None
         self._description = ""
+        self._thumbnail_url: Optional[str] = None
         self._publish_date: Optional[datetime] = None
         self._initial_metadata = initial_metadata
+        self._ytdlp_info: Optional[Dict[str, Any]] = None
 
         self.video_itag = None
         self.audio_itag = None
@@ -348,6 +350,55 @@ class YoutubeLiveStream:
 
         return opts
 
+    def get_ytdlp_info(self, force_update: bool = False) -> Optional[Dict[str, Any]]:
+        if self._ytdlp_info is not None and not force_update:
+            return self._ytdlp_info
+
+        try:
+            with yt_dlp.YoutubeDL(self.get_ytdl_info_opts()) as ydl:
+                self._ytdlp_info = ydl.extract_info(self.url, download=False)
+        except Exception as e:
+            self.log.debug(f"Error getting metadata from yt-dlp: {e}")
+            return self._ytdlp_info
+
+        self.hydrate_metadata_from_ytdlp_info(self._ytdlp_info)
+        return self._ytdlp_info
+
+    def hydrate_metadata_from_ytdlp_info(self, info: Optional[Dict[str, Any]]) -> None:
+        if not info:
+            return
+
+        if not self._title:
+            self._title = info.get("title") or info.get("fulltitle")
+        if not self._author:
+            self._author = info.get("channel") or info.get("uploader")
+        if not self._description:
+            self._description = info.get("description") or ""
+        if not self._thumbnail_url:
+            self._thumbnail_url = info.get("thumbnail")
+            if not self._thumbnail_url and (thumbs := info.get("thumbnails")):
+                self._thumbnail_url = thumbs[-1].get("url")
+        if self._publish_date is None:
+            if timestamp := info.get("release_timestamp") or info.get("timestamp"):
+                self._publish_date = datetime.fromtimestamp(timestamp)
+            else:
+                for key in ("release_date", "upload_date"):
+                    if date_str := info.get(key):
+                        try:
+                            self._publish_date = datetime.strptime(date_str, "%Y%m%d")
+                            break
+                        except ValueError:
+                            continue
+        if self._start_time is None and (timestamp := info.get("release_timestamp") or info.get("timestamp")):
+            self._start_time = datetime.fromtimestamp(
+                timestamp, timezone.utc
+            ).isoformat().replace("+00:00", "Z")
+        if self._scheduled_timestamp is None:
+            release_ts = info.get("release_timestamp")
+            live_status = info.get("live_status")
+            if live_status == "is_upcoming" and release_ts is not None:
+                self._scheduled_timestamp = int(release_ts)
+
     def setup_logger(self, output_path: Path, log_level: str | int):
         if isinstance(log_level, str):
             log_level = str.upper(log_level)
@@ -404,6 +455,11 @@ class YoutubeLiveStream:
         """
         Test for blocked substrings in metadata.
         """
+        if self._title is None and self._initial_metadata is not None:
+            self._title = self._initial_metadata.get("title")
+        if not self._description and self._initial_metadata is not None:
+            self._description = self._initial_metadata.get("description") or ""
+
         title = None
         description = None
         try:
@@ -430,6 +486,7 @@ class YoutubeLiveStream:
         This method will block if the stream is filtered by regex expressions
         until it goes offline.
         """
+        self.get_ytdlp_info()
         download_wanted = self.is_download_wanted()
         if not download_wanted:
             self.skip_download = True
@@ -482,6 +539,7 @@ class YoutubeLiveStream:
             self.log.info(f"Stream {self.video_id} is still active...")
 
             # Keep checking in case the metadata changed
+            self.get_ytdlp_info(force_update=True)
             self.get_metadata()
             download_wanted = self.is_download_wanted()
 
@@ -808,6 +866,10 @@ class YoutubeLiveStream:
         """
         Retrieve value from cached player_response.
         """
+        if self._ytdlp_info is None:
+            self.get_ytdlp_info()
+        if self._title:
+            return self._title
         # This method can be called from outside the class
         try:
             # TODO decode unicode escape sequences if any
@@ -839,6 +901,10 @@ class YoutubeLiveStream:
         """
         Retrieve value from cached player_response.
         """
+        if self._ytdlp_info is None:
+            self.get_ytdlp_info()
+        if self._description:
+            return self._description
         # This method can be called from outside the class
         try:
             return self.player_response["videoDetails"]["shortDescription"]
@@ -850,6 +916,12 @@ class YoutubeLiveStream:
         """
         Get the best thumbnail image URL.
         """
+        if self._thumbnail_url:
+            return self._thumbnail_url
+        if self._ytdlp_info is None:
+            self.get_ytdlp_info()
+        if self._thumbnail_url:
+            return self._thumbnail_url
         # The last item seems to have the maximum size
         best_thumbnail = (
             self.player_response.get("videoDetails", {})
@@ -858,6 +930,7 @@ class YoutubeLiveStream:
             .get('url')
         )
         if best_thumbnail:
+            self._thumbnail_url = best_thumbnail
             return best_thumbnail
         return f"https://img.youtube.com/vi/{self.video_id}/maxresdefault.jpg"
 
@@ -897,6 +970,11 @@ class YoutubeLiveStream:
 
     @property
     def author(self) -> str:
+        if self._author:
+            return self._author
+
+        if self._ytdlp_info is None:
+            self.get_ytdlp_info()
         if self._author:
             return self._author
 
@@ -980,9 +1058,12 @@ class YoutubeLiveStream:
             "audio_itag": self.audio_itag,
             "description": self.description,
         }
-        if self.scheduled_timestamp is not None:
+        scheduled_timestamp = self._scheduled_timestamp
+        if scheduled_timestamp is None and not self.is_muxed_hls:
+            scheduled_timestamp = self.scheduled_timestamp
+        if scheduled_timestamp is not None:
             info["scheduled_time"] = datetime.fromtimestamp(
-                self.scheduled_timestamp
+                scheduled_timestamp
             ).__str__()
 
         if self.video_itag:
@@ -1156,10 +1237,9 @@ class YoutubeLiveStream:
 
 
     def download(self, wait_delay: float = 1.0):
-        with yt_dlp.YoutubeDL(self.get_ytdl_info_opts()) as ydl:
-            info = ydl.extract_info(self.url, download=False)
-            # sanitize_info makes the info json-serializable
-            # print(json.dumps(ydl.sanitize_info(info)))
+        info = self.get_ytdlp_info()
+        if not info:
+            raise Exception("Failed to get stream information from yt-dlp.")
 
         if self.use_ytdl:
             with yt_dlp.YoutubeDL(self.ytdl_opts) as ydl:
@@ -1378,9 +1458,9 @@ class YoutubeLiveStream:
         )[0]
 
     def refresh_hls_format(self) -> None:
-        with yt_dlp.YoutubeDL(self.get_ytdl_info_opts()) as ydl:
-            info = ydl.extract_info(self.url, download=False)
-
+        info = self.get_ytdlp_info(force_update=True)
+        if not info:
+            raise Exception("Failed to refresh stream information from yt-dlp.")
         selected = self.get_best_hls_format(info)
         if not selected:
             raise Exception("Failed to refresh muxed HLS format from yt-dlp.")
@@ -1467,6 +1547,13 @@ class YoutubeLiveStream:
                 return False
         return True
 
+    @staticmethod
+    def build_hls_segment_url(segment_url: str, seg_num: int) -> Optional[str]:
+        updated = re.sub(r"/sq/\d+/", f"/sq/{seg_num}/", segment_url, count=1)
+        if updated == segment_url:
+            return None
+        return updated
+
     def do_download_hls(self, wait_delay: float = 1.0):
         if not self.video_base_url:
             raise Exception("Missing HLS playlist url!")
@@ -1487,11 +1574,44 @@ class YoutubeLiveStream:
                     self.video_base_url,
                     extra_headers=extra_headers
                 )
+                first_available_seq = segments[0][0] if segments else None
+                synthetic_segments: List[tuple[int, str]] = []
+                if first_available_seq is not None and self.seg < first_available_seq:
+                    if template_url := self.build_hls_segment_url(
+                        segments[0][1], self.seg
+                    ):
+                        self.log.info(
+                            "Playlist starts at segment %s but local resume point is %s. "
+                            "Trying direct segment URLs for the gap.",
+                            first_available_seq,
+                            self.seg,
+                        )
+                        synthetic_segments = [
+                            (seg_num, self.build_hls_segment_url(segments[0][1], seg_num))
+                            for seg_num in range(self.seg, first_available_seq)
+                        ]
+                        synthetic_segments = [
+                            (seg_num, seg_url)
+                            for seg_num, seg_url in synthetic_segments
+                            if seg_url is not None
+                        ]
+                    else:
+                        self.log.warning(
+                            "Playlist starts at segment %s but older segment URLs could not "
+                            "be reconstructed. Resuming from %s instead of %s.",
+                            first_available_seq,
+                            first_available_seq,
+                            self.seg,
+                        )
+                        self.seg = first_available_seq
+
                 next_segments = [
                     (seg_num, seg_url)
                     for seg_num, seg_url in segments
                     if seg_num >= self.seg
                 ]
+                if synthetic_segments:
+                    next_segments = synthetic_segments + next_segments
 
                 if not next_segments:
                     if end_list:
@@ -1502,12 +1622,25 @@ class YoutubeLiveStream:
 
                 for seg_num, seg_url in next_segments:
                     self.print_progress(seg_num)
-                    if not self.download_hls_segment(
-                        seg_url,
-                        seg_num,
-                        extra_headers=extra_headers
-                    ):
-                        break
+                    try:
+                        if not self.download_hls_segment(
+                            seg_url,
+                            seg_num,
+                            extra_headers=extra_headers
+                        ):
+                            break
+                    except (urllib.error.HTTPError, urllib.error.URLError) as e:
+                        if first_available_seq is not None and seg_num < first_available_seq:
+                            self.log.warning(
+                                "Failed to fetch older segment %s directly (%s). "
+                                "Resuming from playlist media sequence %s.",
+                                seg_num,
+                                e,
+                                first_available_seq,
+                            )
+                            self.seg = first_available_seq
+                            break
+                        raise
                     self.seg = seg_num + 1
 
                 if end_list and self.seg > next_segments[-1][0]:

--- a/livestream_saver/download.py
+++ b/livestream_saver/download.py
@@ -1770,7 +1770,7 @@ class YoutubeLiveStream:
             clear_line = ('\r\x1b[K' if stderr.isatty() else '\r')
 
         print(clear_line + fullmsg, end='')
-        self.log.info(fullmsg)
+        self.log.debug(fullmsg)
 
     # OBSOLETE
     def print_found_quality(self, item, datatype):

--- a/livestream_saver/livestream_saver.py
+++ b/livestream_saver/livestream_saver.py
@@ -89,7 +89,8 @@ Either a full youtube URL, /channel/ID, or /c/name format.'
         default=argparse.SUPPRESS,
         help='Path to Netscape formatted cookies file.'
     )
-    monitor_parser.add_argument('-q', '--max-video-quality', action='store',
+    monitor_parser.add_argument('-q', '--max-video-width', '--max-video-quality',
+        dest='max_video_width', action='store',
         default=argparse.SUPPRESS, type=int,
         help='Use best available video resolution up to this height in pixels.'\
              ' Example: "360" for maximum height 360p. Get the highest available'
@@ -181,8 +182,8 @@ merging of streams has been successful. Only useful for troubleshooting.'
         default=argparse.SUPPRESS,
         help='Path to Netscape formatted cookies file.'
     )
-    download_parser.add_argument('-q', '--max-video-quality',
-        action='store', type=int,
+    download_parser.add_argument('-q', '--max-video-width', '--max-video-quality',
+        dest='max_video_width', action='store', type=int,
         default=argparse.SUPPRESS,
         help='Use best available video resolution up to this height in pixels.'\
              ' Example: "360" for maximum height 360p. Get the highest available'
@@ -560,8 +561,8 @@ def download_task(
         output_dir=sub_output_dir,
         session=session,
         notifier=NOTIFIER,
-        max_video_quality=config.getint(
-            "monitor", "max_video_quality", vars=args, fallback=None),  # type: ignore
+        max_video_width=config.getint(
+            "monitor", "max_video_width", vars=args, fallback=None),  # type: ignore
         hooks=args["hooks"],
         skip_download=skip_download,
         filters=args["filters"],
@@ -698,8 +699,8 @@ def download_mode(config: ConfigParser, args: Dict[str, Any]):
         output_dir=args["output_dir"],
         session=session,
         notifier=NOTIFIER,
-        max_video_quality=config.getint(
-            "download", "max_video_quality", vars=args, fallback=None
+        max_video_width=config.getint(
+            "download", "max_video_width", vars=args, fallback=None
         ), # type: ignore
         hooks=args["hooks"],
         skip_download=config.getboolean(

--- a/livestream_saver/livestream_saver.py
+++ b/livestream_saver/livestream_saver.py
@@ -49,6 +49,12 @@ def apply_pot_provider_config(ytdlp_config: Dict[str, Any]) -> Dict[str, Any]:
     return ytdlp_config
 
 
+def normalize_path_str(value: Optional[str]) -> Optional[str]:
+    if not value:
+        return value
+    return str(Path(value).expanduser())
+
+
 def parse_args(config) -> argparse.Namespace:
     parent_parser = argparse.ArgumentParser(
         description='Monitor a Youtube channel for any active live stream and \
@@ -997,7 +1003,7 @@ def main():
         args["channel_name"] = channel_name
         args["scan_delay"] = params.get("scan_delay")
         args["hooks"] = params.get("hooks")
-        args["cookies"] = params.get("cookies")
+        args["cookies"] = normalize_path_str(params.get("cookies"))
         args["skip_download"] = params.get("skip_download")
         args["ignore_quality_change"] = params.get("ignore_quality_change")
         args["filters"] = params.get("filters", {})
@@ -1028,7 +1034,9 @@ def main():
         )
         URL = args.get("URL", "")  # pass empty string for get_video_id()
         args["hooks"] = get_hooks_for_section(sub_cmd, config, "_command")
-        args["cookies"] = config.get(sub_cmd, "cookies", vars=args, fallback=None)
+        args["cookies"] = normalize_path_str(
+            config.get(sub_cmd, "cookies", vars=args, fallback=None)
+        )
         args["ignore_quality_change"] = config.getboolean(
             sub_cmd, "ignore_quality_change", vars=args, fallback=False)
 
@@ -1135,6 +1143,8 @@ def main():
 
     if "cookiefile" not in args["ytdlp_config"] and (cookies := args.get("cookies")):
         args["ytdlp_config"]["cookiefile"] = cookies
+    elif cookiefile := args["ytdlp_config"].get("cookiefile"):
+        args["ytdlp_config"]["cookiefile"] = normalize_path_str(cookiefile)
 
     error = 0
     try:

--- a/livestream_saver/livestream_saver.py
+++ b/livestream_saver/livestream_saver.py
@@ -37,9 +37,6 @@ NOTIFIER = NotificationDispatcher()
 TIME_VARIANCE = 3.0  # in minutes
 MAX_SIMULTANEOUS_LIVE_DOWNLOAD = 2
 
-# HACK forcing use of yt-dlp for the time being. 2024/02
-use_ytdl = True
-
 
 def parse_args(config) -> argparse.Namespace:
     parent_parser = argparse.ArgumentParser(
@@ -527,6 +524,8 @@ def download_task(
     args: Dict,
     session: YoutubeUrllibSession
 ):
+    use_ytdl = args.get("use_ytdl", False)
+
     if video in video_processing or video in video_processed:
         log.debug(f"Video already processed or being processed: {video}")
         return
@@ -688,6 +687,8 @@ def monitor_mode(config: ConfigParser, args: Dict[str, Any]):
 
 
 def download_mode(config: ConfigParser, args: Dict[str, Any]):
+    use_ytdl = args.get("use_ytdl", False)
+
     session = YoutubeUrllibSession(
         cookiefile_path=args.get("cookies"), notifier=NOTIFIER
     )
@@ -969,6 +970,7 @@ def main():
     loaded_ytdlp_conf = load_commented_json(ytdlp_conf_file)
 
     args["ytdlp_config"] = loaded_ytdlp_conf
+    args["use_ytdl"] = config.getboolean(sub_cmd, "use_ytdl", vars=args, fallback=False)
 
     logfile_path = Path("")  # cwd by default
     if sub_cmd == "monitor":
@@ -1027,7 +1029,7 @@ def main():
         output_path: Path | None = Path(output_dir) if output_dir else None
         args["output_dir"] = output_path
 
-        if not use_ytdl:
+        if not args["use_ytdl"]:
             output_path = create_output_dir(
                 output_dir=output_path, video_id=video_id)
         else:

--- a/livestream_saver/livestream_saver.py
+++ b/livestream_saver/livestream_saver.py
@@ -38,6 +38,17 @@ TIME_VARIANCE = 3.0  # in minutes
 MAX_SIMULTANEOUS_LIVE_DOWNLOAD = 2
 
 
+def apply_pot_provider_config(ytdlp_config: Dict[str, Any]) -> Dict[str, Any]:
+    pot_provider_url = environ.get("LSS_POT_PROVIDER_URL")
+    if not pot_provider_url:
+        return ytdlp_config
+
+    extractor_args = ytdlp_config.setdefault("extractor_args", {})
+    provider_args = extractor_args.setdefault("youtubepot-bgutilhttp", {})
+    provider_args["base_url"] = [pot_provider_url]
+    return ytdlp_config
+
+
 def parse_args(config) -> argparse.Namespace:
     parent_parser = argparse.ArgumentParser(
         description='Monitor a Youtube channel for any active live stream and \
@@ -967,7 +978,9 @@ def main():
         log.warning(f"{ytdlp_conf_file} not found. Falling back to {fallback}")
         ytdlp_conf_file = fallback
 
-    loaded_ytdlp_conf = load_commented_json(ytdlp_conf_file)
+    loaded_ytdlp_conf = apply_pot_provider_config(
+        load_commented_json(ytdlp_conf_file)
+    )
 
     args["ytdlp_config"] = loaded_ytdlp_conf
     args["use_ytdl"] = config.getboolean(sub_cmd, "use_ytdl", vars=args, fallback=False)

--- a/livestream_saver/merge.py
+++ b/livestream_saver/merge.py
@@ -208,10 +208,10 @@ class ConcatMethod():
             theoretical_dur,
         )
         if round_dur == theoretical_dur:
-            logger.warning(
-                "Duration is invalid, but it seems to correspond to the total "
-                f"number of files we should have in theory ({last_segnum})."
-                " We assume we recorded only part of the stream & duration is valid.")
+            logger.info(
+                "Duration differs from ffprobe's expected total, but it matches "
+                "the duration implied by the available segments. "
+                "Assuming the recording is valid.")
             return True
 
         logger.warning(
@@ -464,10 +464,16 @@ def path_list_to_int(seg_list: List[Path]) -> Iterator[int]:
     return (int(i.stem[:-6]) for i in seg_list)
 
 
-def merge(info: Dict, data_dir: Path,
-          output_dir: Optional[Path] = None,
-          keep_concat: bool = False,
-          delete_source: bool = False) -> Optional[Path]:
+def merge(
+    info: Dict,
+    data_dir: Path,
+    output_dir: Optional[Path] = None,
+    keep_concat: bool = False,
+    delete_source: bool = False
+) -> Optional[Path]:
+    """
+    Merge the video and audio segments into a single file.
+    """
     if not output_dir:
         output_dir = data_dir
 
@@ -505,7 +511,7 @@ def merge(info: Dict, data_dir: Path,
     audio_seg_dir = data_dir / "aud"
 
     video_files = collect(video_seg_dir)
-    audio_files = collect(audio_seg_dir)
+    audio_files = collect(audio_seg_dir, warn_missing=False)
 
     if not video_files and not audio_files:
         raise Exception("Missing video or audio segment source files!")
@@ -757,6 +763,7 @@ def merge(info: Dict, data_dir: Path,
     # TODO check final duration just in case.
 
     logger.info('Successfully wrote file "%s".', final_output_file.name)
+    rename_thumbnail(data_dir, final_output_file)
 
     if not keep_concat:
         if concat_audio_file:
@@ -791,7 +798,7 @@ def merge(info: Dict, data_dir: Path,
                 logger.info("Deleting source segments in %s...", video_seg_dir)
             else:
                 logger.info(
-                    "Deleting source segments in %s and %s...", 
+                    "Deleting source segments in %s and %s...",
                     video_seg_dir, audio_seg_dir
                 )
             rmtree(video_seg_dir)
@@ -1015,9 +1022,37 @@ def get_thumbnail_pathname(data_path: Path) -> Optional[Path]:
     return None
 
 
-def collect(data_path: Path) -> List[Path]:
+def rename_thumbnail(data_path: Path, final_output_file: Path) -> Optional[Path]:
+    thumb_path = get_thumbnail_pathname(data_path)
+    if not thumb_path or not thumb_path.exists():
+        return None
+
+    filetype = get_filetype(thumb_path)
+    if not filetype:
+        logger.warning('Could not determine thumbnail type for "%s".', thumb_path)
+        return None
+
+    suffix = ".jpg" if filetype == "jpeg" else f".{filetype}"
+    new_path = final_output_file.with_suffix(suffix)
+    if thumb_path == new_path:
+        return new_path
+
+    try:
+        thumb_path.rename(new_path)
+    except FileExistsError:
+        logger.info('Thumbnail "%s" already exists. Keeping it.', new_path)
+    except OSError as exc:
+        logger.warning('Failed to rename thumbnail "%s" to "%s": %s', thumb_path, new_path, exc)
+        return None
+    else:
+        logger.info('Renamed thumbnail "%s" to "%s".', thumb_path.name, new_path.name)
+    return new_path
+
+
+def collect(data_path: Path, warn_missing: bool = True) -> List[Path]:
     if not data_path.exists():
-        logger.warning(f"{data_path} does not exist!")
+        if warn_missing:
+            logger.warning("%s does not exist!", data_path)
         return []
     files = [p for p in data_path.glob('*.ts')]
     files.sort()

--- a/livestream_saver/merge.py
+++ b/livestream_saver/merge.py
@@ -510,9 +510,11 @@ def merge(info: Dict, data_dir: Path,
     if not video_files and not audio_files:
         raise Exception("Missing video or audio segment source files!")
 
+    muxed_only = bool(video_files and not audio_files)
+
     # Various checks on source segments to detect any missing:
     segment_number_mismatch = False
-    if len(video_files) != len(audio_files):
+    if not muxed_only and len(video_files) != len(audio_files):
         logger.warning(
             "Number of audio and video segments do not match! "
             f"{len(video_files)} video segments, {len(audio_files)} audio segments."
@@ -521,7 +523,7 @@ def merge(info: Dict, data_dir: Path,
 
     # FIXME this is redundant with checks below
     missing_video_paths = print_missing_segments(video_files, "_video")
-    missing_audio_paths = print_missing_segments(audio_files, "_audio")
+    missing_audio_paths = [] if muxed_only else print_missing_segments(audio_files, "_audio")
     if missing_video_paths or missing_audio_paths:
         segment_number_mismatch = True
         logger.warning(f"Some segments appear to be missing!")
@@ -530,23 +532,27 @@ def merge(info: Dict, data_dir: Path,
     missing_video_ints = []
     missing_audio_ints = []
     video_as_int = list(path_list_to_int(video_files))
-    audio_as_int = list(path_list_to_int(audio_files))
+    audio_as_int = [] if muxed_only else list(path_list_to_int(audio_files))
     seg_list_as_ints = video_as_int + audio_as_int
 
-    affected_segs = [
-        i for i in seg_list_as_ints
-        if i not in video_as_int or i not in audio_as_int
-    ]
-    missing_audio_ints = [i for i in video_as_int if i not in audio_as_int]
-    missing_video_ints = [i for i in audio_as_int if i not in video_as_int]
-    if affected_segs:
-        logger.warning(
-            "Some segments appear to be missing! "
-            f" Affected segments: {affected_segs}. "
-            f" Missing video segments: {missing_video_ints}."
-            f" Missing audio segments: {missing_audio_ints}")
+    if muxed_only:
+        affected_segs = []
+        logger.info("Detected a single muxed segment track. Skipping A/V parity checks.")
     else:
-        logger.info("No missing segment detected. All good.")
+        affected_segs = [
+            i for i in seg_list_as_ints
+            if i not in video_as_int or i not in audio_as_int
+        ]
+        missing_audio_ints = [i for i in video_as_int if i not in audio_as_int]
+        missing_video_ints = [i for i in audio_as_int if i not in video_as_int]
+        if affected_segs:
+            logger.warning(
+                "Some segments appear to be missing! "
+                f" Affected segments: {affected_segs}. "
+                f" Missing video segments: {missing_video_ints}."
+                f" Missing audio segments: {missing_audio_ints}")
+        else:
+            logger.info("No missing segment detected. All good.")
     del video_as_int
     del audio_as_int
     del seg_list_as_ints
@@ -554,14 +560,15 @@ def merge(info: Dict, data_dir: Path,
 
     # Determine codec from one file
     vid_props = probe(video_files[0])
-    aud_props = probe(audio_files[0])
+    aud_props = {} if muxed_only else probe(audio_files[0])
 
     # We could either remove to balance both lists, or fill in. Removing
     # is probably better here, especially regarding audio.
     video_files = list(filter(
         lambda f: segname_to_int(f) not in missing_video_ints, video_files))
-    audio_files = list(filter(
-        lambda f: segname_to_int(f) not in missing_audio_ints, audio_files))
+    if not muxed_only:
+        audio_files = list(filter(
+            lambda f: segname_to_int(f) not in missing_audio_ints, audio_files))
 
     # There is only one method that works currently
     methods = (NativeConcatFile,)
@@ -597,25 +604,26 @@ def merge(info: Dict, data_dir: Path,
                 # audio_files = list(filter(
                 #    lambda f: segname_to_int(f) not in new_missing, audio_files))
 
-            concat_audio_file = methods[attempt](
-                audio_files, aud_props.get("codec_name", "audio"),
-                info.get("id", "UNKNOWN_ID"), output_dir,
-                missing_audio_ints, corrupt_aud_segs)
-            concat_audio_file.make()
-            if concat_audio_file.error is not None:
-                got_errors = True
+            if not muxed_only:
+                concat_audio_file = methods[attempt](
+                    audio_files, aud_props.get("codec_name", "audio"),
+                    info.get("id", "UNKNOWN_ID"), output_dir,
+                    missing_audio_ints, corrupt_aud_segs)
+                concat_audio_file.make()
+                if concat_audio_file.error is not None:
+                    got_errors = True
 
-            # We have to rebuild the video after removing video segments
-            # corresponding to the corrupt audio segments:
-            # FIXME this is untested! Need some corrupt audio segments.
-            if concat_audio_file._corrupt_segments:
-                corrupt_aud_segs = concat_audio_file._corrupt_segments
-                new_missing = list(path_list_to_int(corrupt_aud_segs))
-                video_files = list(filter(
-                    lambda f: segname_to_int(f) not in new_missing, video_files))
-                concat_video_file.unlink(missing_ok=True)
-                concat_video_file.segment_list = video_files
-                concat_video_file.make(overwrite=True)
+                # We have to rebuild the video after removing video segments
+                # corresponding to the corrupt audio segments:
+                # FIXME this is untested! Need some corrupt audio segments.
+                if concat_audio_file._corrupt_segments:
+                    corrupt_aud_segs = concat_audio_file._corrupt_segments
+                    new_missing = list(path_list_to_int(corrupt_aud_segs))
+                    video_files = list(filter(
+                        lambda f: segname_to_int(f) not in new_missing, video_files))
+                    concat_video_file.unlink(missing_ok=True)
+                    concat_video_file.segment_list = video_files
+                    concat_video_file.make(overwrite=True)
             break
         except Exception as e:
             logger.exception(e)
@@ -633,30 +641,33 @@ def merge(info: Dict, data_dir: Path,
 
     if not concat_video_file or not concat_video_file.exists():
         raise Exception(f"Missing concat video file: {concat_video_file}")
-    if not concat_audio_file or not concat_audio_file.exists():
+    if not muxed_only and (not concat_audio_file or not concat_audio_file.exists()):
         raise Exception(f"Missing concat audio file: {concat_audio_file}")
 
     # Compare durations of each track:
     concats_have_different_durations = False
     concat_vid_props = probe(concat_video_file._final_file)
-    concat_aud_props = probe(concat_audio_file._final_file)
+    concat_aud_props = probe(concat_audio_file._final_file) if concat_audio_file else {}
     # cast to int to round down
-    dur_dirr = abs(
-        round(concat_aud_props.get("duration", 0.0)) \
-        - round(concat_vid_props.get("duration", 0.0))
-    )
-    if dur_dirr <= 1:
-        logger.info("No duration mismatch between concat files. All good.")
-    # We may tolerate up to 2 seconds delta, but won't delete source files:
-    if dur_dirr > 1:
-        logger.warning( "Track duration mismatch: "
-            f"Audio duration {concat_aud_props.get('duration')}, "
-            f"Video duration {concat_vid_props.get('duration')}. ")
-        concats_have_different_durations = True
-    if dur_dirr > 2:
-        logger.warning(
-            "Aborting due to concat files duration difference superior to 2 seconds.")
-        return None
+    if muxed_only:
+        dur_dirr = 0
+    else:
+        dur_dirr = abs(
+            round(concat_aud_props.get("duration", 0.0)) \
+            - round(concat_vid_props.get("duration", 0.0))
+        )
+        if dur_dirr <= 1:
+            logger.info("No duration mismatch between concat files. All good.")
+        # We may tolerate up to 2 seconds delta, but won't delete source files:
+        if dur_dirr > 1:
+            logger.warning( "Track duration mismatch: "
+                f"Audio duration {concat_aud_props.get('duration')}, "
+                f"Video duration {concat_vid_props.get('duration')}. ")
+            concats_have_different_durations = True
+        if dur_dirr > 2:
+            logger.warning(
+                "Aborting due to concat files duration difference superior to 2 seconds.")
+            return None
 
     ext = "mp4"
     # Seems like an MP4 container can handle vp9 just fine. Perhaps we don't
@@ -682,15 +693,15 @@ def merge(info: Dict, data_dir: Path,
     # Final muxing of tracks, plus thumbnail and metadata embedding:
     try_thumb = True
     while True:
-        ffmpeg_command = [
-            "ffmpeg", "-hide_banner", "-y",
-            # "-vsync", "2",
-            "-i", str(concat_video_file),
-            "-i", str(concat_audio_file)
-        ]
+        ffmpeg_command = ["ffmpeg", "-hide_banner", "-y", "-i", str(concat_video_file)]
+        input_count = 1
+        if not muxed_only:
+            ffmpeg_command.extend(["-i", str(concat_audio_file)])
+            input_count = 2
         metadata_cmd = metadata_arguments(
             info, data_dir,
-            want_thumb=try_thumb
+            want_thumb=try_thumb,
+            input_count=input_count
         )
         # ffmpeg -hide_banner -i video.mp4 -i audio.m4a -i thumbnail.jpg -map 0
         # -map 1 -map 2 -c:v:2 jpg -disposition:v:1 attached_pic -c copy out.mp4
@@ -748,12 +759,18 @@ def merge(info: Dict, data_dir: Path,
     logger.info('Successfully wrote file "%s".', final_output_file.name)
 
     if not keep_concat:
-        logger.debug(
-            "Removing temporary audio/video concatenated files %s and %s",
-            concat_audio_file.name,
-            concat_video_file.name,
-        )
-        concat_audio_file.unlink()
+        if concat_audio_file:
+            logger.debug(
+                "Removing temporary audio/video concatenated files %s and %s",
+                concat_audio_file.name,
+                concat_video_file.name,
+            )
+            concat_audio_file.unlink()
+        else:
+            logger.debug(
+                "Removing temporary muxed concatenated file %s",
+                concat_video_file.name,
+            )
         concat_video_file.unlink()
 
     if delete_source:
@@ -770,11 +787,15 @@ def merge(info: Dict, data_dir: Path,
         elif got_errors:
             logger.warning(f"We got suspicious errors while concatenating. {action_msg}")
         else:
-            logger.info("Deleting source segments in {} and {}...".format(
-                video_seg_dir, audio_seg_dir)
-            )
+            if muxed_only:
+                logger.info("Deleting source segments in %s...", video_seg_dir)
+            else:
+                logger.info("Deleting source segments in {} and {}...".format(
+                    video_seg_dir, audio_seg_dir)
+                )
             rmtree(video_seg_dir)
-            rmtree(audio_seg_dir)
+            if audio_seg_dir.exists():
+                rmtree(audio_seg_dir)
 
     return final_output_file
 
@@ -901,12 +922,13 @@ def print_missing_segments(filelist: List[Path], filetype: str) -> List[Path]:
 def metadata_arguments(
     info: Dict,
     data_path: Path,
-    want_thumb: bool = True
+    want_thumb: bool = True,
+    input_count: int = 2
 ) -> List[str]:
     cmd = []
     # Embed thumbnail if a valid one is found
     if want_thumb:
-        cmd = get_thumbnail_command_prefix(data_path)
+        cmd = get_thumbnail_command_prefix(data_path, input_count=input_count)
 
     # These have to be placed AFTER, otherwise they affect one stream in particular
     if title := info.get('title'):
@@ -924,7 +946,7 @@ def get_filetype(path: Path) -> str | None:
     return guess_extension(path)
 
 
-def get_thumbnail_command_prefix(data_path: Path) -> List:
+def get_thumbnail_command_prefix(data_path: Path, input_count: int = 2) -> List:
     thumb_path = get_thumbnail_pathname(data_path)
     if not thumb_path:
         return []
@@ -948,15 +970,14 @@ def get_thumbnail_command_prefix(data_path: Path) -> List:
             return []
 
     # https://ffmpeg.org/ffmpeg.html#toc-Stream-selection
-    return [
-        "-i", str(thumb_path),
-        "-map", "0", "-map", "1", "-map", "2",
-        # "-c:v:2", _type,
-        # copy probably means no re-encoding again into jpg/png
-        "-c:a:2", "copy",
+    cmd = ["-i", str(thumb_path)]
+    for idx in range(input_count + 1):
+        cmd.extend(["-map", str(idx)])
+    cmd.extend([
         "-disposition:v:1",
         "attached_pic"
-    ]
+    ])
+    return cmd
 
 
 def convert_thumbnail(thumb_path: Path, fromformat: str) -> Path:

--- a/livestream_saver/merge.py
+++ b/livestream_saver/merge.py
@@ -760,14 +760,14 @@ def merge(info: Dict, data_dir: Path,
 
     if not keep_concat:
         if concat_audio_file:
-            logger.debug(
+            logger.info(
                 "Removing temporary audio/video concatenated files %s and %s",
                 concat_audio_file.name,
                 concat_video_file.name,
             )
             concat_audio_file.unlink()
         else:
-            logger.debug(
+            logger.info(
                 "Removing temporary muxed concatenated file %s",
                 concat_video_file.name,
             )
@@ -776,22 +776,23 @@ def merge(info: Dict, data_dir: Path,
     if delete_source:
         action_msg = "Not deleting source segments."
         if segment_number_mismatch:
-            logger.warning(f"Some segments are missing. {action_msg}")
+            logger.warning("Some segments are missing. %s", action_msg)
         elif concats_have_different_durations:
             logger.warning(
-                f"There was a track duration mismatch. {action_msg}")
+                "There was a track duration mismatch. %s", action_msg)
         elif corrupt_aud_segs or corrupt_vid_segs:
-            logger.warning(f"Some segments were corrupted! {action_msg}")
+            logger.warning("Some segments were corrupted! %s", action_msg)
         elif attempt > 0:
-            logger.warning(f"A concat method failed. {action_msg}")
+            logger.warning("A concat method failed. %s", action_msg)
         elif got_errors:
-            logger.warning(f"We got suspicious errors while concatenating. {action_msg}")
+            logger.warning("We got suspicious errors while concatenating. %s", action_msg)
         else:
             if muxed_only:
                 logger.info("Deleting source segments in %s...", video_seg_dir)
             else:
-                logger.info("Deleting source segments in {} and {}...".format(
-                    video_seg_dir, audio_seg_dir)
+                logger.info(
+                    "Deleting source segments in %s and %s...", 
+                    video_seg_dir, audio_seg_dir
                 )
             rmtree(video_seg_dir)
             if audio_seg_dir.exists():
@@ -817,18 +818,18 @@ def get_corrupt(filelist: List[Path]) -> List[Path]:
                 capture_output=True, text=True
             )
             # logger.debug(f"{probeproc.args} stderr output:\n{probeproc.stderr}")
-        except FileNotFoundError as e:
-            logger.error(f"Failed to use ffprobe: {e}.")
+        except FileNotFoundError as exc:
+            logger.error("Failed to use ffprobe: %s.", exc)
         else:
             if "Packet corrupt" in probeproc.stderr:
-                logger.warning(f"File segment \"{f}\" is corrupt!")
+                logger.warning("File segment \"%s\" is corrupt!", f)
                 corrupt.append(f)
 
     if corrupt:
         logger.warning(
-            f"Found {len(corrupt)} corrupt packets via ffprobe: "
-            f"{[f.name for f in corrupt]}."
-            " Will not use them anymore")
+            "Found %s corrupt packets via ffprobe: "
+            "%s."
+            " Will not use them anymore", len(corrupt), [f.name for f in corrupt])
     else:
         logger.info("No corrupt file detected.")
     return corrupt
@@ -960,12 +961,12 @@ def get_thumbnail_command_prefix(data_path: Path, input_count: int = 2) -> List:
     if _type not in ("jpg", "jpeg", "png"):
         try:
             convert_thumbnail(thumb_path, _type)
-        except Exception as e:
+        except Exception as exc:
             logger.error(
                 'Failed converting thumbnail "%s" from detected %s format. %s',
                 thumb_path,
                 _type,
-                e,
+                exc,
             )
             return []
 
@@ -985,9 +986,9 @@ def convert_thumbnail(thumb_path: Path, fromformat: str) -> Path:
     then convert the file to PNG and saves it as 'filename' from thumb_path."""
     try:
         from PIL import Image
-    except ImportError as e:
-        logger.error(f"Failed loading PIL (pillow) module. {e}")
-        raise e
+    except ImportError as exc:
+        logger.error("Failed loading PIL (pillow) module. %s", exc)
+        raise
 
     # old_path = str(thumb_path)
     # new_name = ".".join((old_path, fromformat))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,13 @@ dependencies = [
     "pytube == 10.9.2",
     "Pillow",
     "yt-dlp",
-    "bgutil_ytdlp_pot_provider",
     "filetype == 1.2.0"
+]
+
+[project.optional-dependencies]
+opt = [
+    "bgutil_ytdlp_pot_provider",
+    "yt-dlp-ejs",
 ]
 
 [project.urls]  # Optional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "livestream_saver"
-version = "1.0.0"
+version = "2.0.0"
 description = "Monitor Youtube channels to download live streams"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/requirements-opt.txt
+++ b/requirements-opt.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+bgutil-ytdlp-pot-provider
+yt-dlp-ejs

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,4 @@
 pytube==10.9.2
 Pillow
-# streamlink
-# streamlink_cli
 yt-dlp
-# git+https://github.com/yt-dlp/yt-dlp
-bgutil-ytdlp-pot-provider
-yt-dlp-ejs
 filetype==1.2.0


### PR DESCRIPTION
* ytdlp is broken when using cookies and asking for specific stream resolutions, so this uses ytdlp only to fetch stream manifest URLs
* support downloading segments from HLS streams
* BREAKING: rename parameter MAX_VIDEO_QUALITY to MAX_VIDEO_WIDTH
* allow the end-user to choose whether or not to use ytdlp as the downloader
* improve logic robustness when resuming download when existing segments exist in local storage